### PR TITLE
Updated tags.conf and windowrules.conf to the new windowrules format after 0.53.2

### DIFF
--- a/config/hypr/confs/tags.conf
+++ b/config/hypr/confs/tags.conf
@@ -1,22 +1,86 @@
 # all the needed tags here
 
 # browser tags
-windowrulev2 = tag +browser, class:^([Ff]irefox|org.mozilla.firefox|[Ff]irefox-esr|[Ff]irefox-bin)$
-windowrulev2 = tag +browser, class:^([Gg]oogle-chrome(-beta|-dev|-unstable)?)$
-windowrulev2 = tag +browser, class:^(chrome-.+-Default)$ # Chrome PWAs
-windowrulev2 = tag +browser, class:^([Cc]hromium)$
-windowrulev2 = tag +browser, class:^([Mm]icrosoft-edge(-stable|-beta|-dev|-unstable))$
-windowrulev2 = tag +browser, class:^([Bb]rave-browser(-beta|-dev|-unstable)?)$
-windowrulev2 = tag +browser, class:^([Tt]horium-browser|[Cc]achy-browser)$
-windowrulev2 = tag +browser, class:^(zen-alpha|zen)$
+windowrule {
+  name = windowrule-1
+  tag = +browser
+  match:class = ^([Ff]irefox|org.mozilla.firefox|[Ff]irefox-esr|[Ff]irefox-bin)$
+}
+
+windowrule {
+  name = windowrule-2
+  tag = +browser
+  match:class = ^([Gg]oogle-chrome(-beta|-dev|-unstable)?)$
+}
+
+windowrule {
+  name = windowrule-3
+  tag = +browser
+  match:class = ^(chrome-.+-Default)$ # Chrome PWAs
+}
+
+windowrule {
+  name = windowrule-4
+  tag = +browser
+  match:class = ^([Cc]hromium)$
+}
+
+windowrule {
+  name = windowrule-5
+  tag = +browser
+  match:class = ^([Mm]icrosoft-edge(-stable|-beta|-dev|-unstable))$
+}
+
+windowrule {
+  name = windowrule-6
+  tag = +browser
+  match:class = ^([Bb]rave-browser(-beta|-dev|-unstable)?)$
+}
+
+windowrule {
+  name = windowrule-7
+  tag = +browser
+  match:class = ^([Tt]horium-browser|[Cc]achy-browser)$
+}
+
+windowrule {
+  name = windowrule-8
+  tag = +browser
+  match:class = ^(zen-alpha|zen)$
+}
+
 
 # terminal
-windowrulev2 = tag +terminal, class:^(Alacritty|kitty|kitty-dropterm)$
+windowrule {
+  name = windowrule-9
+  tag = +terminal
+  match:class = ^(Alacritty|kitty|kitty-dropterm)$
+}
+
 
 # file manager
-windowrulev2 = tag +file-manager, class:^([Tt]hunar|org.gnome.Nautilus|[Pp]cmanfm-qt)$
+windowrule {
+  name = windowrule-10
+  tag = +file-manager
+  match:class = ^([Tt]hunar|org.gnome.Nautilus|[Pp]cmanfm-qt)$
+}
+
 
 # ide
-windowrulev2 = tag +ide, class:^(codium|codium-url-handler|VSCodium)$
-windowrulev2 = tag +ide, class:^(VSCode|code-url-handler|code)$
-windowrulev2 = tag +ide, class:^(jetbrains-.+)$ # JetBrains IDEs
+windowrule {
+  name = windowrule-11
+  tag = +ide
+  match:class = ^(codium|codium-url-handler|VSCodium)$
+}
+
+windowrule {
+  name = windowrule-12
+  tag = +ide
+  match:class = ^(VSCode|code-url-handler|code)$
+}
+
+windowrule {
+  name = windowrule-13
+  tag = +ide
+  match:class = ^(jetbrains-.+)$ # JetBrains IDEs
+}

--- a/config/hypr/confs/windowrules.conf
+++ b/config/hypr/confs/windowrules.conf
@@ -6,97 +6,352 @@ source = ~/.config/hypr/confs/configs.conf
 source = ~/.config/hypr/confs/tags.conf
 
 # floating
-windowrulev2 = float, class:^(org.kde.polkit-kde-authentication-agent-1)$
-windowrulev2 = float, class:^(xfce-polkit)$
-windowrulev2 = float, tag:file-manager*, title:(File Operation Progress)
-windowrulev2 = float, class:([Tt]hunar), title:(Confirm to replace files)
-windowrulev2 = float, class:^(pavucontrol|org.pulseaudio.pavucontrol)$
-windowrulev2 = float, class:^(nwg-look|qt5ct|qt6ct|mpv)$
-windowrulev2 = float, class:^(kitty)$,title:(update)
-windowrulev2 = float, class:^(kitty)$,title:(yazi)
-windowrulev2 = float, class:^(kitty)$,title:(monitor)
-windowrulev2 = float, class:^(kitty)$,title:(browser)
-windowrulev2 = float, class:^(kitty)$,title:(floating)
-windowrulev2 = float, class:^(file-roller|org.gnome.FileRoller)$ # archive manager
-windowrulev2 = float, class:^([Kk]vantummanager)$
-windowrulev2 = float, class:^([Ll]xappearance)$
-windowrulev2 = float, class:^(yad)$
-windowrulev2 = float, class:^(eog)$
-windowrulev2 = float, class:^([Tt]hunar)$
-windowrulev2 = float, class:^([Gg]nome-disks)$
-windowrulev2 = float, class:^(com.obsproject.Studio)$
-windowrulev2 = float, class:^(org.kde.kcalc)$
-windowrulev2 = float, class:^(org.telegram.desktop)$
-windowrulev2 = float, class:^(org.kde.partitionmanager)$
-windowrulev2 = float, class:^(org.kde.gwenview)$
+windowrule {
+  name = windowrule-1
+  float = on
+  match:class = ^(org.kde.polkit-kde-authentication-agent-1)$
+}
+
+windowrule {
+  name = windowrule-2
+  float = on
+  size = (monitor_w*0.3) (monitor_h*0.2)
+  match:class = ^(xfce-polkit)$
+}
+
+windowrule {
+  name = windowrule-3
+  float = on
+  match:tag = file-manager*
+  match:title = (File Operation Progress)
+}
+
+windowrule {
+  name = windowrule-4
+  float = on
+  center = on
+  match:class = ([Tt]hunar)
+  match:title = (Confirm to replace files)
+}
+
+windowrule {
+  name = windowrule-5
+  float = on
+  size = (monitor_w*0.6) (monitor_h*0.7)
+  match:class = ^(pavucontrol|org.pulseaudio.pavucontrol)$
+}
+
+windowrule {
+  name = windowrule-6
+  float = on
+  size = (monitor_w*0.6) (monitor_h*0.7)
+  match:class = ^(nwg-look|qt5ct|qt6ct|mpv)$
+}
+
+windowrule {
+  name = windowrule-7
+  float = on
+  size = (monitor_w*0.6) (monitor_h*0.7)
+  match:class = ^(kitty)$
+  match:title = (update)
+}
+
+windowrule {
+  name = windowrule-8
+  float = on
+  size = (monitor_w*0.6) (monitor_h*0.6)
+  match:class = ^(kitty)$
+  match:title = (yazi)
+}
+
+windowrule {
+  name = windowrule-9
+  float = on
+  size = (monitor_w*0.5) (monitor_h*0.55)
+  match:class = ^(kitty)$
+  match:title = (monitor)
+}
+
+windowrule {
+  name = windowrule-10
+  float = on
+  size = (monitor_w*0.5) (monitor_h*0.6)
+  match:class = ^(kitty)$
+  match:title = (browser)
+}
+
+windowrule {
+  name = windowrule-11
+  float = on
+  size = (monitor_w*0.7) (monitor_h*0.8)
+  match:class = ^(kitty)$
+  match:title = (floating)
+}
+
+windowrule {
+  name = windowrule-12
+  float = on
+  match:class = ^(file-roller|org.gnome.FileRoller)$ # archive manager
+}
+
+windowrule {
+  name = windowrule-13
+  float = on
+  size = (monitor_w*0.6) (monitor_h*0.8)
+  match:class = ^([Kk]vantummanager)$
+}
+
+windowrule {
+  name = windowrule-14
+  float = on
+  size = (monitor_w*0.6) (monitor_h*0.8)
+  match:class = ^([Ll]xappearance)$
+}
+
+windowrule {
+  name = windowrule-15
+  float = on
+  center = on
+  match:class = ^(yad)$
+}
+
+windowrule {
+  name = windowrule-16
+  float = on
+  size = (monitor_w*0.6) (monitor_h*0.8)
+  match:class = ^(eog)$
+}
+
+windowrule {
+  name = windowrule-17
+  float = on
+  size = (monitor_w*0.6) (monitor_h*0.8)
+  match:class = ^([Tt]hunar)$
+}
+
+windowrule {
+  name = windowrule-18
+  float = on
+  match:class = ^([Gg]nome-disks)$
+}
+
+windowrule {
+  name = windowrule-19
+  float = on
+  size = (monitor_w*0.5) (monitor_h*0.8)
+  workspace = 3
+  match:class = ^(com.obsproject.Studio)$
+}
+
+windowrule {
+  name = windowrule-20
+  float = on
+  size = (monitor_w*0.3) (monitor_h*0.55)
+  match:class = ^(org.kde.kcalc)$
+}
+
+windowrule {
+  name = windowrule-21
+  float = on
+  size = (monitor_w*0.6) (monitor_h*0.8)
+  match:class = ^(org.telegram.desktop)$
+}
+
+windowrule {
+  name = windowrule-22
+  float = on
+  size = (monitor_w*0.5) (monitor_h*0.6)
+  match:class = ^(org.kde.partitionmanager)$
+}
+
+windowrule {
+  name = windowrule-23
+  float = on
+  size = (monitor_w*0.6) (monitor_h*0.8)
+  match:class = ^(org.kde.gwenview)$
+}
 
 
-windowrulev2 = float, title:^(Authentication Required)$
-windowrulev2 = center, title:^(Authentication Required)$
-windowrulev2 = float, class:(codium|codium-url-handler|VSCodium), title:negative:(.*codium.*|.*VSCodium.*)
-windowrulev2 = float, class:^(com.heroicgameslauncher.hgl)$, title:negative:(Heroic Games Launcher)
-windowrulev2 = float, class:^([Ss]team)$, title:negative:^([Ss]team)$
-windowrulev2 = float, class:([Tt]hunar), title:negative:(.*[Tt]hunar.*)
-windowrulev2 = float, class:(xdg-desktop-portal-gtk)
-windowrulev2 = float, class:(electron), title:(Add Folder to Workspace)
-windowrulev2 = float, title:^(Add Folder to Workspace)$
-windowrulev2 = float, tag:browser*, initialTitle:^(wants to open)$
-windowrulev2 = float, initialTitle:(Open Files)
+
+windowrule {
+  name = windowrule-24
+  float = on
+  center = on
+  match:title = ^(Authentication Required)$
+}
+
+windowrule {
+  name = windowrule-25
+  float = on
+  match:class = (codium|codium-url-handler|VSCodium)
+  match:title = negative:(.*codium.*|.*VSCodium.*)
+}
+
+windowrule {
+  name = windowrule-26
+  float = on
+  match:class = ^(com.heroicgameslauncher.hgl)$
+  match:title = negative:(Heroic Games Launcher)
+}
+
+windowrule {
+  name = windowrule-27
+  float = on
+  match:class = ^([Ss]team)$
+  match:title = negative:^([Ss]team)$
+}
+
+windowrule {
+  name = windowrule-28
+  float = on
+  match:class = ([Tt]hunar)
+  match:title = negative:(.*[Tt]hunar.*)
+}
+
+windowrule {
+  name = windowrule-29
+  float = on
+  match:class = (xdg-desktop-portal-gtk)
+}
+
+windowrule {
+  name = windowrule-30
+  float = on
+  match:class = (electron)
+  match:title = (Add Folder to Workspace)
+}
+
+windowrule {
+  name = windowrule-31
+  float = on
+  match:title = ^(Add Folder to Workspace)$
+}
+
+windowrule {
+  name = windowrule-32
+  float = on
+  match:tag = browser*
+  match:initial_title = ^(wants to open)$
+}
+
+windowrule {
+  name = windowrule-33
+  float = on
+  match:initial_title = (Open Files)
+}
+
 
 # size
-windowrulev2 = size 60% 80%, class:^([Kk]vantummanager)$
-windowrulev2 = size 60% 80%, class:^([Ll]xappearance)$
-windowrulev2 = size 60% 80%, class:^(nwg-look)$
-windowrulev2 = size 60% 80%, class:^(eog)$
-windowrulev2 = size 60% 80%, class:^([Tt]hunar)$
-windowrulev2 = size 20% 40%, class:^([Tt]hunar)$, title:(File Operation Progress)
-windowrulev2 = size 20% 40%, class:^([Tt]hunar)$, title:(Confirm to replace files)
-windowrulev2 = size 70% 70%, class:^(xdg-desktop-portal-gtk)$
-windowrulev2 = size 60% 70%, title:(Kvantum Manager)
-windowrulev2 = size 60% 70%, class:^(nwg-look|qt5ct|qt6ct|mpv)$
-windowrulev2 = size 60% 70%, class:^(pavucontrol|org.pulseaudio.pavucontrol)$
-windowrulev2 = size 60% 70%, class:^(kitty)$,title:(update)
-windowrulev2 = size 60% 60%, class:^(kitty)$,title:(yazi)
-windowrulev2 = size 50% 55%, class:^(kitty)$,title:(monitor)
-windowrulev2 = size 50% 60%, class:^(kitty)$,title:(browser)
-windowrulev2 = size 70% 80%, class:^(kitty)$,title:(floating)
-windowrulev2 = size 50% 80%, class:^(com.obsproject.Studio)$
-windowrulev2 = size 60% 80%, class:^(org.telegram.desktop)$
-windowrulev2 = size 60% 80%, class:^(org.kde.gwenview)$
-windowrulev2 = size 50% 60%, class:^(org.kde.partitionmanager)$
-windowrulev2 = size 30% 55%, class:^(org.kde.kcalc)$
-windowrulev2 = size 30% 20%, class:^(xfce-polkit)$
+windowrule {
+  name = windowrule-34
+  size = (monitor_w*0.6) (monitor_h*0.8)
+  center = on
+  match:class = ^(nwg-look)$
+}
+
+windowrule {
+  name = windowrule-35
+  size = (monitor_w*0.2) (monitor_h*0.4)
+  match:class = ^([Tt]hunar)$
+  match:title = (File Operation Progress)
+}
+
+windowrule {
+  name = windowrule-36
+  size = (monitor_w*0.2) (monitor_h*0.4)
+  match:class = ^([Tt]hunar)$
+  match:title = (Confirm to replace files)
+}
+
+windowrule {
+  name = windowrule-37
+  size = (monitor_w*0.7) (monitor_h*0.7)
+  match:class = ^(xdg-desktop-portal-gtk)$
+}
+
+windowrule {
+  name = windowrule-38
+  size = (monitor_w*0.6) (monitor_h*0.7)
+  match:title = (Kvantum Manager)
+}
+
 
 # windowrule v2 - position
-windowrulev2 = center, class:([Tt]hunar), title:(File Operation Progress)
-windowrulev2 = center, class:([Tt]hunar), title:(Confirm to replace files)
-windowrulev2 = center, class:^(nwg-look)$
-windowrulev2 = center, class:^(qt5ct)$
-windowrulev2 = center, class:^(lxappearance)$
-windowrulev2 = center, class:^(yad)$
-windowrulev2 = center, class:^(kitty)$,title:(yazi|update|browser)
+windowrule {
+  name = windowrule-39
+  center = on
+  match:class = ([Tt]hunar)
+  match:title = (File Operation Progress)
+}
+
+windowrule {
+  name = windowrule-40
+  center = on
+  match:class = ^(qt5ct)$
+}
+
+windowrule {
+  name = windowrule-41
+  center = on
+  match:class = ^(lxappearance)$
+}
+
+windowrule {
+  name = windowrule-42
+  center = on
+  match:class = ^(kitty)$
+  match:title = (yazi|update|browser)
+}
+
 
 # opacity
-windowrulev2 = opacity $opacity_act $opacity_deact, tag:ide*
-windowrulev2 = opacity $opacity_act $opacity_deact, tag:terminal*
-windowrulev2 = opacity $opacity_act $opacity_deact, tag:file-manager*
-windowrulev2 = opacity 1.0 $opacity_deact, tag:browser*
+windowrule {
+  name = windowrule-43
+  opacity = $opacity_act $opacity_deact
+  workspace = 3
+  match:tag = ide*
+}
+
+windowrule {
+  name = windowrule-44
+  opacity = $opacity_act $opacity_deact
+  match:tag = terminal*
+}
+
+windowrule {
+  name = windowrule-45
+  opacity = $opacity_act $opacity_deact
+  match:tag = file-manager*
+}
+
+windowrule {
+  name = windowrule-46
+  opacity = 1.0 $opacity_deact
+  workspace = 2
+  match:tag = browser*
+}
+
 
 # open in workspaces
-windowrulev2 = workspace 1, class:^(kitty)$,title:(main)
+windowrule {
+  name = windowrule-47
+  workspace = 1
+  match:class = ^(kitty)$
+  match:title = (main)
+}
+
 # windowrulev2 = workspace 1, tag:terminal*
-windowrulev2 = workspace 2, tag:browser*
-windowrulev2 = workspace 3, tag:ide*
-windowrulev2 = workspace 3, class:^(com.obsproject.Studio)$
 
 workspace = special:exposed,gapsout:60,gapsin:30,bordersize:5,border:true,shadow:false
 
 layerrule = match:namespace rofi, blur on
 layerrule = match:namespace notifications, blur on
 
-layerrule = blur :wlogout_dialog
-layerrule = blur swaync-control-center
-layerrule = blur swaync-notification-window
+layerrule {
+  name = layerrule-1
+  blur = swaync-notification-window
+}
+
 
 blurls = code
 


### PR DESCRIPTION
Hyprland 0.53.2 revamped the way on how windowrules work. This fix reimplements it in the new format.
Also worthy to note, its now just windowrule and not windowrulev2